### PR TITLE
Update mopidy to 3.0 and python from 2 to 3.7

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,6 +10,6 @@ variables:
   ADDON_ARMHF: "false"
   ADDON_AARCH64: "false"
 
-  ADDON_AMD64_BASE: "hassioaddons/ubuntu-base-amd64:4.0.3"
-  ADDON_ARMV7_BASE: "hassioaddons/ubuntu-base-armv7:4.0.3"
-  ADDON_I386_BASE: "hassioaddons/ubuntu-base-i386:4.0.3"
+  ADDON_AMD64_BASE: "hassioaddons/debian-base-amd64:2.0.1"
+  ADDON_ARMV7_BASE: "hassioaddons/debian-base-armv7:2.0.1"
+  ADDON_I386_BASE: "hassioaddons/debian-base-i386:2.0.1"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,6 +10,6 @@ variables:
   ADDON_ARMHF: "false"
   ADDON_AARCH64: "false"
 
-  ADDON_AMD64_BASE: "hassioaddons/ubuntu-base-amd64:3.1.2"
-  ADDON_ARMV7_BASE: "hassioaddons/ubuntu-base-armv7:3.1.2"
-  ADDON_I386_BASE: "hassioaddons/ubuntu-base-i386:3.1.2"
+  ADDON_AMD64_BASE: "hassioaddons/ubuntu-base-amd64:4.0.3"
+  ADDON_ARMV7_BASE: "hassioaddons/ubuntu-base-armv7:4.0.3"
+  ADDON_I386_BASE: "hassioaddons/ubuntu-base-i386:4.0.3"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,6 +10,6 @@ variables:
   ADDON_ARMHF: "false"
   ADDON_AARCH64: "false"
 
-  ADDON_AMD64_BASE: "hassioaddons/debian-base-amd64:2.0.1"
-  ADDON_ARMV7_BASE: "hassioaddons/debian-base-armv7:2.0.1"
-  ADDON_I386_BASE: "hassioaddons/debian-base-i386:2.0.1"
+  ADDON_AMD64_BASE: "hassioaddons/debian-base-amd64:3.0.0"
+  ADDON_ARMV7_BASE: "hassioaddons/debian-base-armv7:3.0.0"
+  ADDON_I386_BASE: "hassioaddons/debian-base-i386:3.0.0"

--- a/mopidy/Dockerfile
+++ b/mopidy/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=hassioaddons/debian-base:2.0.1
+ARG BUILD_FROM=hassioaddons/debian-base:3.0.0
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 

--- a/mopidy/Dockerfile
+++ b/mopidy/Dockerfile
@@ -39,12 +39,10 @@ RUN \
         python3-gi \
         python3-gst-1.0 \
         gstreamer1.0-alsa \
-        gstreamer1.0-plugins-base \
         gstreamer1.0-plugins-bad \
         gstreamer1.0-plugins-good \
         gstreamer1.0-plugins-ugly \
         gstreamer1.0-pulseaudio \
-        gstreamer1.0-tools \
     \
     && luarocks install lua-resty-http 0.13-0 \
     \

--- a/mopidy/Dockerfile
+++ b/mopidy/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=hassioaddons/ubuntu-base:3.0.0
+ARG BUILD_FROM=hassioaddons/ubuntu-base:4.0.3
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 

--- a/mopidy/Dockerfile
+++ b/mopidy/Dockerfile
@@ -75,6 +75,9 @@ RUN \
         /root/.cache \
     && find /tmp/ -mindepth 1  -delete
 
+# Move access.log to stdout and error.log to stderr
+RUN mkdir -p /var/log/nginx && ln -sf /dev/stdout /var/log/nginx/access.log && ln -sf /dev/stderr /var/log/nginx/error.log
+
 # Copy root filesystem
 COPY rootfs /
 

--- a/mopidy/Dockerfile
+++ b/mopidy/Dockerfile
@@ -36,9 +36,15 @@ RUN \
         zlib1g-dev \
         build-essential \
         python3-dev \
+        python3-gi \
+        python3-gst-1.0 \
         gstreamer1.0-alsa \
+        gstreamer1.0-plugins-base \
         gstreamer1.0-plugins-bad \
+        gstreamer1.0-plugins-good \
+        gstreamer1.0-plugins-ugly \
         gstreamer1.0-pulseaudio \
+        gstreamer1.0-tools \
     \
     && luarocks install lua-resty-http 0.13-0 \
     \

--- a/mopidy/Dockerfile
+++ b/mopidy/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=hassioaddons/ubuntu-base:3.1.2
+ARG BUILD_FROM=hassioaddons/ubuntu-base:3.0.0
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
@@ -13,14 +13,13 @@ RUN \
     apt-get update \
     \
     && apt-get install -y --no-install-recommends \
-        libssl1.1=1.1.1-1ubuntu2.1~18.04.2 \
-    && apt-get install -y --no-install-recommends \
-        dirmngr=2.2.4-1ubuntu1.2 \
-        gpg-agent=2.2.4-1ubuntu1.2 \
-        gpg=2.2.4-1ubuntu1.2 \
-        libnginx-mod-http-lua=1.14.0-0ubuntu1.2 \
-        luarocks=2.4.2+dfsg-1 \
-        nginx=1.14.0-0ubuntu1.2 \
+        dirmngr \
+        gpg-agent \
+        gpg \
+        libnginx-mod-http-lua \
+        luarocks \
+        nginx \
+        git \
     \
     && curl -L https://apt.mopidy.com/mopidy.gpg | apt-key add - \
     && curl -L https://apt.mopidy.com/mopidy.list -o /etc/apt/sources.list.d/mopidy.list \
@@ -28,55 +27,49 @@ RUN \
     && apt-get update \
     \
     && apt-get install -y --no-install-recommends \
-        build-essential=12.4ubuntu1 \
-        gstreamer1.0-alsa=1.14.1-1ubuntu1~ubuntu18.04.2 \
-        gstreamer1.0-plugins-bad=1.14.1-1ubuntu1~ubuntu18.04.1 \
-        gstreamer1.0-pulseaudio=1.14.1-1ubuntu1~ubuntu18.04.1 \
-        libffi-dev=3.2.1-8 \
-        libxml2-dev=2.9.4+dfsg1-6.1ubuntu1.2 \
-        libxslt1-dev=1.1.29-5ubuntu0.1 \
-        mopidy-alsamixer=1.0.3-3 \
-        mopidy-local-sqlite=1.0.0-2 \
-        mopidy-spotify-tunigo=1.0.0-0mopidy1 \
-        mopidy-spotify=3.1.0-0mopidy1 \
-        mopidy=2.2.2-1 \
-        python-dev=2.7.15~rc1-1 \
-        zlib1g-dev=1:1.2.11.dfsg-0ubuntu2 \
-    \
-    && luarocks install lua-resty-http 0.13-0 \
-    \
-    && curl https://bootstrap.pypa.io/get-pip.py | python \
-    && pip install --no-cache-dir -r /tmp/requirements.txt \
-    \
-    && find /usr/local/lib/python2.7/ -type d -name tests -depth -exec rm -rf {} \; \
-    && find /usr/local/lib/python2.7/ -type d -name test -depth -exec rm -rf {} \; \
-    && find /usr/local/lib/python2.7/ -name __pycache__ -depth -exec rm -rf {} \; \
-    && find /usr/local/lib/python2.7/ -name "*.pyc" -depth -exec rm -f {} \; \
-    \
-    && apt-get purge -y --auto-remove \
-        build-essential \
-        dirmngr \
-        dpkg-dev \
-        gcc \
-        gcc-7 \
-        gpg \
-        gpg-agent \
         libffi-dev \
         libxml2-dev \
         libxslt1-dev \
-        luarocks \
-        python-dev \
+        libasound2-dev \
+        libspotify12 \
+        libspotify-dev \
         zlib1g-dev \
+        build-essential \
+        python3-dev \
+        gstreamer1.0-alsa \
+        gstreamer1.0-plugins-bad \
+        gstreamer1.0-pulseaudio \
     \
-    && find /tmp/ -mindepth 1  -delete \
+    && luarocks install lua-resty-http 0.13-0 \
+    \
+    && curl https://bootstrap.pypa.io/get-pip.py | python3 \
+    && pip3 install --no-cache-dir -r /tmp/requirements.txt \
+    \
+    && find /usr/local/lib/python3.6/ -type d -name tests -depth -exec rm -rf {} \; \
+    && find /usr/local/lib/python3.6/ -type d -name test -depth -exec rm -rf {} \; \
+    && find /usr/local/lib/python3.6/ -name __pycache__ -depth -exec rm -rf {} \; \
+    && find /usr/local/lib/python3.6/ -name "*.pyc" -depth -exec rm -f {} \; \
+    \
+    && apt-get purge -y --auto-remove \
+        dirmngr \
+        gpg-agent \
+        gpg \
+        git \
+        libffi-dev \
+        libxml2-dev \
+        libxslt1-dev \
+        zlib1g-dev \
+        build-essential \
+        gcc \
+        python-dev \
+        dpkg-dev \
+        gcc-7 \
+        luarocks \
     && rm -fr \
-        /etc/nginx \
         /var/{cache,log}/* \
         /var/lib/apt/lists/* \
         /root/.cache \
-    \
-    && mkdir -p /var/log/nginx \
-    && touch /var/log/nginx/error.log
+    && find /tmp/ -mindepth 1  -delete
 
 # Copy root filesystem
 COPY rootfs /

--- a/mopidy/Dockerfile
+++ b/mopidy/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=hassioaddons/ubuntu-base:4.0.3
+ARG BUILD_FROM=hassioaddons/debian-base:2.0.1
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
@@ -45,10 +45,10 @@ RUN \
     && curl https://bootstrap.pypa.io/get-pip.py | python3 \
     && pip3 install --no-cache-dir -r /tmp/requirements.txt \
     \
-    && find /usr/local/lib/python3.6/ -type d -name tests -depth -exec rm -rf {} \; \
-    && find /usr/local/lib/python3.6/ -type d -name test -depth -exec rm -rf {} \; \
-    && find /usr/local/lib/python3.6/ -name __pycache__ -depth -exec rm -rf {} \; \
-    && find /usr/local/lib/python3.6/ -name "*.pyc" -depth -exec rm -f {} \; \
+    && find /usr/local/lib/python3.7/ -type d -name tests -depth -exec rm -rf {} \; \
+    && find /usr/local/lib/python3.7/ -type d -name test -depth -exec rm -rf {} \; \
+    && find /usr/local/lib/python3.7/ -name __pycache__ -depth -exec rm -rf {} \; \
+    && find /usr/local/lib/python3.7/ -name "*.pyc" -depth -exec rm -f {} \; \
     \
     && apt-get purge -y --auto-remove \
         dirmngr \

--- a/mopidy/build.json
+++ b/mopidy/build.json
@@ -1,8 +1,8 @@
 {
     "build_from": {
-        "amd64": "hassioaddons/debian-base-amd64:2.0.1",
-        "armv7": "hassioaddons/debian-base-armv7:2.0.1",
-        "i386": "hassioaddons/debian-base-i386:2.0.1"
+        "amd64": "hassioaddons/debian-base-amd64:3.0.0",
+        "armv7": "hassioaddons/debian-base-armv7:3.0.0",
+        "i386": "hassioaddons/debian-base-i386:3.0.0"
     },
     "args": {}
 }

--- a/mopidy/build.json
+++ b/mopidy/build.json
@@ -1,8 +1,8 @@
 {
     "build_from": {
-        "amd64": "hassioaddons/ubuntu-base-amd64:4.0.3",
-        "armv7": "hassioaddons/ubuntu-base-armv7:4.0.3",
-        "i386": "hassioaddons/ubuntu-base-i386:4.0.3"
+        "amd64": "hassioaddons/debian-base-amd64:2.0.1",
+        "armv7": "hassioaddons/debian-base-armv7:2.0.1",
+        "i386": "hassioaddons/debian-base-i386:2.0.1"
     },
     "args": {}
 }

--- a/mopidy/build.json
+++ b/mopidy/build.json
@@ -1,8 +1,8 @@
 {
     "build_from": {
-        "amd64": "hassioaddons/ubuntu-base-amd64:3.1.2",
-        "armv7": "hassioaddons/ubuntu-base-armv7:3.1.2",
-        "i386": "hassioaddons/ubuntu-base-i386:3.1.2"
+        "amd64": "hassioaddons/ubuntu-base-amd64:4.0.3",
+        "armv7": "hassioaddons/ubuntu-base-armv7:4.0.3",
+        "i386": "hassioaddons/ubuntu-base-i386:4.0.3"
     },
     "args": {}
 }

--- a/mopidy/requirements.txt
+++ b/mopidy/requirements.txt
@@ -1,3 +1,7 @@
-Mopidy-GMusic==3.0.0
-Mopidy-Iris==3.39.0
-Mopidy-SoundCloud==2.1.0
+Mopidy
+Pykka
+Mopidy-AlsaMixer
+Mopidy-Spotify
+Mopidy-Iris
+Mopidy-SoundCloud
+Mopidy-GMusic

--- a/mopidy/requirements.txt
+++ b/mopidy/requirements.txt
@@ -1,7 +1,7 @@
-Mopidy
-Pykka
-Mopidy-AlsaMixer
-Mopidy-Spotify
-Mopidy-Iris
-Mopidy-SoundCloud
-Mopidy-GMusic
+Mopidy==3.0.1
+Pykka==2.0.2
+Mopidy-AlsaMixer==2.0.0
+Mopidy-Spotify==4.0.0
+Mopidy-Iris==3.43.0
+Mopidy-SoundCloud==3.0.0
+Mopidy-GMusic==4.0.0

--- a/mopidy/requirements.txt
+++ b/mopidy/requirements.txt
@@ -3,7 +3,7 @@ Pykka==2.0.2
 Mopidy-Local==3.1.0
 Mopidy-AlsaMixer==2.0.0
 Mopidy-Spotify==4.0.0
-Mopidy-Iris==3.43.0
+git+https://github.com/jaedb/Iris.git@develop
 Mopidy-SoundCloud==3.0.0
 Mopidy-GMusic==4.0.0
 Mopidy-Youtube==3.0a1

--- a/mopidy/requirements.txt
+++ b/mopidy/requirements.txt
@@ -1,7 +1,9 @@
 Mopidy==3.0.1
 Pykka==2.0.2
+Mopidy-Local==3.1.0
 Mopidy-AlsaMixer==2.0.0
 Mopidy-Spotify==4.0.0
 Mopidy-Iris==3.43.0
 Mopidy-SoundCloud==3.0.0
 Mopidy-GMusic==4.0.0
+Mopidy-Youtube==3.0a1

--- a/mopidy/requirements.txt
+++ b/mopidy/requirements.txt
@@ -1,8 +1,8 @@
 Mopidy==3.0.1
 Pykka==2.0.2
-Mopidy-Local==3.1.0
+Mopidy-Local==3.1.1
 Mopidy-AlsaMixer==2.0.0
-Mopidy-Spotify==4.0.0
+Mopidy-Spotify==4.0.1
 git+https://github.com/jaedb/Iris.git@develop
 Mopidy-SoundCloud==3.0.0
 Mopidy-GMusic==4.0.0

--- a/mopidy/requirements.txt
+++ b/mopidy/requirements.txt
@@ -3,7 +3,7 @@ Pykka==2.0.2
 Mopidy-Local==3.1.1
 Mopidy-AlsaMixer==2.0.0
 Mopidy-Spotify==4.0.1
-git+https://github.com/jaedb/Iris.git@3.44.0
+Mopidy-Iris==3.44.0
 Mopidy-SoundCloud==3.0.0
 Mopidy-GMusic==4.0.0
 Mopidy-Youtube==3.0a1

--- a/mopidy/requirements.txt
+++ b/mopidy/requirements.txt
@@ -3,7 +3,7 @@ Pykka==2.0.2
 Mopidy-Local==3.1.1
 Mopidy-AlsaMixer==2.0.0
 Mopidy-Spotify==4.0.1
-git+https://github.com/jaedb/Iris.git@develop
+git+https://github.com/jaedb/Iris.git@3.44.0
 Mopidy-SoundCloud==3.0.0
 Mopidy-GMusic==4.0.0
 Mopidy-Youtube==3.0a1


### PR DESCRIPTION
# Proposed Changes

Changed code to meetup with conform python3.

- Updated mopidy to 3.0
- Updated all plugins to let them work with mopidy 3.0
- Updated python from 2 to 3
- Updated ubuntu-base to debian-base 3.0.0
- Added nginx log folder for error.log and access.log so we got no more nginx errors
```
# Move access.log to stdout and error.log to stderr
RUN mkdir -p /var/log/nginx && ln -sf /dev/stdout /var/log/nginx/access.log && ln -sf /dev/stderr /var/log/nginx/error.log
```