### PR TITLE
Features/extension/mopidy mpd

### DIFF
--- a/mopidy/requirements.txt
+++ b/mopidy/requirements.txt
@@ -7,3 +7,4 @@ Mopidy-Iris==3.46.0
 Mopidy-SoundCloud==3.0.0
 Mopidy-GMusic==4.0.0
 Mopidy-Youtube==3.0
+Mopidy-MPD==3.0.0

--- a/mopidy/rootfs/etc/cont-init.d/20-folders.sh
+++ b/mopidy/rootfs/etc/cont-init.d/20-folders.sh
@@ -5,6 +5,6 @@
 # ==============================================================================
 readonly MEDIA_DIR="/share/mopidy/media"
 
-if ! bashio::fs.directory_exist "${MEDIA_DIR}"; then
+if ! bashio::fs.directory_exists "${MEDIA_DIR}"; then
   mkdir -p "${MEDIA_DIR}" || bashio::exit.nok "Could not create media folder: ${MEDIA_DIR}"
 fi


### PR DESCRIPTION
# Proposed Changes

- Adding the [Mopidy-MPD](https://github.com/mopidy/mopidy-mpd) extension to allow the control of Mopidy from inside HA.
- Also a typo fix wich caused my local dev-addon to crash while checking if directories existed.

## Related Issues

#30 

The local version is up and running, implementing the alarm-clock I mentioned in the issue.