### PR TITLE
Remove webui configuration, as Ingress is enabled on this add-on

### DIFF
--- a/mopidy/config.json
+++ b/mopidy/config.json
@@ -5,7 +5,6 @@
   "panel_icon": "mdi:music-circle",
   "description": "Mopidy is an extensible music server",
   "url": "https://github.com/hassio-addons/addon-mopidy",
-  "webui": "http://[HOST]:[PORT:80]/iris/",
   "ingress": true,
   "ingress_port": 1337,
   "ingress_entry": "iris/",


### PR DESCRIPTION
# Proposed Changes

This add-on has Ingress enabled, so setting the `webui` configuration option has no effect.
